### PR TITLE
Migrate from fest-assert to AssertJ

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -98,7 +98,7 @@
     <version.mp-jwt-auth>1.0</version.mp-jwt-auth>
 
     <version.arquillian-core>1.2.1.Final</version.arquillian-core>
-    <version.fest-assert>1.4</version.fest-assert>
+    <version.assertj>3.10.0</version.assertj>
     <version.junit>4.12</version.junit>
     <version.testng>6.9.9</version.testng>
     <version.rest-assured>3.0.6</version.rest-assured>
@@ -755,9 +755,9 @@
         <version>${version.testng}</version>
       </dependency>
       <dependency>
-        <groupId>org.easytesting</groupId>
-        <artifactId>fest-assert</artifactId>
-        <version>${version.fest-assert}</version>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/core/health/src/test/java/io/thorntail/health/EndpointTest.java
+++ b/core/health/src/test/java/io/thorntail/health/EndpointTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 public class EndpointTest {

--- a/core/kernel/src/test/java/io/thorntail/condition/ConditionTest.java
+++ b/core/kernel/src/test/java/io/thorntail/condition/ConditionTest.java
@@ -7,7 +7,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/core/kernel/src/test/java/io/thorntail/config/ext/InjectionCoercerTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/ext/InjectionCoercerTest.java
@@ -9,13 +9,13 @@ import javax.enterprise.util.TypeLiteral;
 import javax.inject.Provider;
 
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import io.thorntail.config.impl.ConfigImpl;
 import io.thorntail.config.impl.sources.MapConfigSource;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/core/kernel/src/test/java/io/thorntail/config/impl/ArraySplitterTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/ArraySplitterTest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/1/18.

--- a/core/kernel/src/test/java/io/thorntail/config/impl/ConfigTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/ConfigTest.java
@@ -7,7 +7,7 @@ import io.thorntail.config.impl.sources.MapConfigSource;
 import org.eclipse.microprofile.config.Config;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigTest {
 

--- a/core/kernel/src/test/java/io/thorntail/config/impl/converters/fallback/EnumValueOfConverterTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/converters/fallback/EnumValueOfConverterTest.java
@@ -2,11 +2,11 @@ package io.thorntail.config.impl.converters.fallback;
 
 import java.util.concurrent.TimeUnit;
 
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 public class EnumValueOfConverterTest {
 

--- a/core/kernel/src/test/java/io/thorntail/config/impl/converters/fallback/StaticValueOfConverterTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/converters/fallback/StaticValueOfConverterTest.java
@@ -1,9 +1,9 @@
 package io.thorntail.config.impl.converters.fallback;
 
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StaticValueOfConverterTest {
 

--- a/core/kernel/src/test/java/io/thorntail/config/impl/interpolation/ExpressionParserTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/interpolation/ExpressionParserTest.java
@@ -1,9 +1,9 @@
 package io.thorntail.config.impl.interpolation;
 
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/core/kernel/src/test/java/io/thorntail/config/impl/interpolation/InterpolatorTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/interpolation/InterpolatorTest.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/core/kernel/src/test/java/io/thorntail/config/impl/sources/YamlConfigSourceTest.java
+++ b/core/kernel/src/test/java/io/thorntail/config/impl/sources/YamlConfigSourceTest.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/6/18.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -79,8 +79,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/core/testing/pom.xml
+++ b/core/testing/pom.xml
@@ -31,8 +31,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/core/testing/src/test/java/io/thorntail/test/TestRunnerTest.java
+++ b/core/testing/src/test/java/io/thorntail/test/TestRunnerTest.java
@@ -4,11 +4,11 @@ import javax.inject.Inject;
 
 import io.thorntail.Thorntail;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 1/19/18.

--- a/core/testutils-opentracing-jaeger/pom.xml
+++ b/core/testutils-opentracing-jaeger/pom.xml
@@ -14,8 +14,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/core/testutils-opentracing-jaeger/src/main/java/io/thorntail/testutils/opentracing/jaeger/SpanNodeAssert.java
+++ b/core/testutils-opentracing-jaeger/src/main/java/io/thorntail/testutils/opentracing/jaeger/SpanNodeAssert.java
@@ -1,8 +1,8 @@
 package io.thorntail.testutils.opentracing.jaeger;
 
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/27/18.

--- a/core/testutils-opentracing-jaeger/src/main/java/io/thorntail/testutils/opentracing/jaeger/SpanTreeAssert.java
+++ b/core/testutils-opentracing-jaeger/src/main/java/io/thorntail/testutils/opentracing/jaeger/SpanTreeAssert.java
@@ -1,8 +1,8 @@
 package io.thorntail.testutils.opentracing.jaeger;
 
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/27/18.

--- a/core/testutils-opentracing/pom.xml
+++ b/core/testutils-opentracing/pom.xml
@@ -19,8 +19,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/core/testutils-opentracing/src/main/java/io/thorntail/testutils/opentracing/SpanNodeAssert.java
+++ b/core/testutils-opentracing/src/main/java/io/thorntail/testutils/opentracing/SpanNodeAssert.java
@@ -1,6 +1,6 @@
 package io.thorntail.testutils.opentracing;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/27/18.

--- a/core/testutils-opentracing/src/main/java/io/thorntail/testutils/opentracing/SpanTreeAssert.java
+++ b/core/testutils-opentracing/src/main/java/io/thorntail/testutils/opentracing/SpanTreeAssert.java
@@ -1,8 +1,8 @@
 package io.thorntail.testutils.opentracing;
 
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/27/18.

--- a/docs/src/main/asciidoc/tools/testing-junit.adoc
+++ b/docs/src/main/asciidoc/tools/testing-junit.adoc
@@ -55,9 +55,9 @@ This may be useful when running tests on a CI machine or if you wish to parallel
 In order to know what port are actually selected and in-use, you may `@Inject` either a `@Primary` or `@Management` `URL` or `InetSocketAddress` component.
 These instances are made available throw the xref:component-servlet[Servlet] component.
 
-.fest-assert
+.assertj
 
-The `testing` artifact transitively brings in https://github.com/alexruiz/fest-assert-2.x[fest-assert] for making fluent assertions in your tests.
+The `testing` artifact transitively brings in http://joel-costigliola.github.io/assertj/index.html[assertj] for making fluent assertions in your tests.
 
 .RestAssured
 

--- a/testsuite/docker/docker-fabric8/src/it/java/io/thorntail/testsuite/docker/DockerAppIT.java
+++ b/testsuite/docker/docker-fabric8/src/it/java/io/thorntail/testsuite/docker/DockerAppIT.java
@@ -15,7 +15,7 @@ import junit.framework.AssertionFailedError;
 import org.junit.Test;
 
 import static junit.framework.TestCase.fail;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/14/18.

--- a/testsuite/docker/docker-thin-layers/src/it/java/io/thorntail/testsuite/docker/DockerAppIT.java
+++ b/testsuite/docker/docker-thin-layers/src/it/java/io/thorntail/testsuite/docker/DockerAppIT.java
@@ -15,7 +15,7 @@ import junit.framework.AssertionFailedError;
 import org.junit.Test;
 
 import static junit.framework.TestCase.fail;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/14/18.

--- a/testsuite/docker/jms/src/it/java/io/thorntail/testsuite/jms/basic/JMSAppIT.java
+++ b/testsuite/docker/jms/src/it/java/io/thorntail/testsuite/jms/basic/JMSAppIT.java
@@ -11,7 +11,7 @@ import io.thorntail.test.ThorntailTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 @EphemeralPorts

--- a/testsuite/docker/jms/src/it/java/io/thorntail/testsuite/jms/driven/MessageDrivenIT.java
+++ b/testsuite/docker/jms/src/it/java/io/thorntail/testsuite/jms/driven/MessageDrivenIT.java
@@ -8,7 +8,7 @@ import io.thorntail.test.ThorntailTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 @EphemeralPorts

--- a/testsuite/docker/opentracing-jaeger/src/it/java/io/thorntail/testsuite/opentracing/jaeger/OpenTracingJaegerAppIT.java
+++ b/testsuite/docker/opentracing-jaeger/src/it/java/io/thorntail/testsuite/opentracing/jaeger/OpenTracingJaegerAppIT.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static io.thorntail.testutils.opentracing.jaeger.SpanNode.assertThat;
 import static io.thorntail.testutils.opentracing.jaeger.SpanTree.assertThat;
 

--- a/testsuite/simple/bean-validation/src/test/java/io/thorntail/bean/validation/BeanValidationTest.java
+++ b/testsuite/simple/bean-validation/src/test/java/io/thorntail/bean/validation/BeanValidationTest.java
@@ -10,7 +10,7 @@ import io.thorntail.test.ThorntailTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 3/26/18.

--- a/testsuite/simple/config/src/test/java/io/thorntail/testsuite/config/ConfigTest.java
+++ b/testsuite/simple/config/src/test/java/io/thorntail/testsuite/config/ConfigTest.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 public class ConfigTest {

--- a/testsuite/simple/jaxrs-jsonp/src/test/java/io/thorntail/testsuite/jaxrs/jsonp/JAXRSJSONPAppTest.java
+++ b/testsuite/simple/jaxrs-jsonp/src/test/java/io/thorntail/testsuite/jaxrs/jsonp/JAXRSJSONPAppTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 public class JAXRSJSONPAppTest {

--- a/testsuite/simple/jpa-contracts/src/test/java/io/thorntail/testsuite/jpa_contracts/JPAAppTest.java
+++ b/testsuite/simple/jpa-contracts/src/test/java/io/thorntail/testsuite/jpa_contracts/JPAAppTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
 import io.thorntail.testsuite.jpa_contracts.jpa_impl.EnforcedEntityManagerFactory;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 public class JPAAppTest {

--- a/testsuite/simple/jpa-jta/src/test/java/io/thorntail/testsuite/jpajta/JPAJTAAppTest.java
+++ b/testsuite/simple/jpa-jta/src/test/java/io/thorntail/testsuite/jpajta/JPAJTAAppTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/testsuite/simple/jpa-opentracing/src/test/java/io/thorntail/testsuite/jpa/opentracing/JPAOpenTracingAppTest.java
+++ b/testsuite/simple/jpa-opentracing/src/test/java/io/thorntail/testsuite/jpa/opentracing/JPAOpenTracingAppTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 public class JPAOpenTracingAppTest {

--- a/testsuite/simple/jpa/src/test/java/io/thorntail/testsuite/jpa/JPAAppTest.java
+++ b/testsuite/simple/jpa/src/test/java/io/thorntail/testsuite/jpa/JPAAppTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.when;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ThorntailTestRunner.class)
 public class JPAAppTest {

--- a/testsuite/simple/vertx/src/it/java/io/thorntail/testsuite/vertx/VertxIT.java
+++ b/testsuite/simple/vertx/src/it/java/io/thorntail/testsuite/vertx/VertxIT.java
@@ -7,7 +7,7 @@ import io.vertx.resourceadapter.VertxEventBus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 2/12/18.

--- a/testsuite/simple/websockets/src/test/java/io/thorntail/testsuite/websockets/WebSocketsAppTest.java
+++ b/testsuite/simple/websockets/src/test/java/io/thorntail/testsuite/websockets/WebSocketsAppTest.java
@@ -5,12 +5,12 @@ import java.net.URI;
 import javax.inject.Inject;
 
 import io.thorntail.test.ThorntailTestRunner;
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import io.thorntail.servlet.annotation.Primary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by bob on 4/6/18.


### PR DESCRIPTION
fest-assert is not actively maintained anymore and users are suggested to migrate to assertj